### PR TITLE
Bug/google maps fix

### DIFF
--- a/meetpy/meetpy/settings/base.py
+++ b/meetpy/meetpy/settings/base.py
@@ -103,7 +103,7 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = get_secret('SECRET_KEY')
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/meetpy/templates/includes/maps_api_script.html
+++ b/meetpy/templates/includes/maps_api_script.html
@@ -1,0 +1,19 @@
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBhNca45HD9Q_OMp-g2qNlSLwmOqaKCwXs&amp;sensor=false"></script>
+<script type="text/javascript">
+    function initialize() {
+        var venue = new google.maps.LatLng({{ latitude }}, {{ longitude }});
+        var mapOptions = {
+            center: venue,
+            zoom: {% if zoom %}{{ zoom }}{% else %}12{% endif %},
+            disableDefaultUI: {% if disable_ui %}true{% else %}false{% endif %},
+            mapTypeId: google.maps.MapTypeId.ROADMAP,
+            scrollwheel: false
+        };
+        var map = new google.maps.Map(document.getElementById("{{ canvas_id }}"), mapOptions);
+        var marker = new google.maps.Marker({
+            position: venue
+        });
+        marker.setMap(map);
+    }
+    google.maps.event.addDomListener(window, 'load', initialize);
+</script>

--- a/meetpy/templates/meetups/meetup_detail.html
+++ b/meetpy/templates/meetups/meetup_detail.html
@@ -14,24 +14,7 @@
 {% block js %}
 <script type="text/javascript" src="{% static 'js/load-image.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/bootstrap-image-gallery.js' %}"></script>
-<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBhNca45HD9Q_OMp-g2qNlSLwmOqaKCwXs&amp;sensor=false"></script>
-<script type="text/javascript">
-    function initialize() {
-        var venue = new google.maps.LatLng({{ object.venue.latitude }}, {{ object.venue.longitude }});
-        var mapOptions = {
-            center: venue,
-            zoom: 12,
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
-            scrollwheel: false
-        };
-        var map = new google.maps.Map(document.getElementById("map-canvas"), mapOptions);
-        var marker = new google.maps.Marker({
-            position: venue
-        });
-        marker.setMap(map);
-    }
-    google.maps.event.addDomListener(window, 'load', initialize);
-</script>
+{% include 'includes/maps_api_script.html' with canvas_id='map-canvas' latitude=object.venue.latitude longitude=object.venue.longitude %}
 {% endblock %}
 
 {% block content %}

--- a/meetpy/templates/misc/home.html
+++ b/meetpy/templates/misc/home.html
@@ -6,6 +6,10 @@
 
 {% block og_title %}Home{% endblock %}
 
+{% block js %}
+{% include 'includes/maps_api_script.html' with canvas_id='map-canvas' latitude=upcoming_meetup.venue.latitude longitude=upcoming_meetup.venue.longitude zoom=15 disable_ui=1 %}
+{% endblock %}
+
 {% block content %}
 <div class="container">
     {% if upcoming_meetup %}
@@ -24,9 +28,7 @@
             <h5 class="location"><img src="{% static 'img/location.png' %}" alt="Lokalizacja" class="icon-location-home"> {{ upcoming_meetup.venue.name }}, {{ upcoming_meetup.venue.address }}</h5>
             <div class="text-center">
                 <div class="clearfix">
-                    <a href="https://maps.google.com/maps?q={{ upcoming_meetup.venue.latitude }},{{ upcoming_meetup.venue.longitude }}" target="_blank">
-                        <img src="https://maps.googleapis.com/maps/api/staticmap?zoom=15&amp;size=460x189&amp;maptype=roadmap&amp;markers=color:blue%7C{{ upcoming_meetup.venue.latitude }},{{ upcoming_meetup.venue.longitude }}&amp;sensor=false" class="map" alt="Mapa">
-                    </a>
+                    <div class="map" id="map-canvas"></div>
                 </div>
                 <a href="{{ upcoming_meetup.get_absolute_url }}" class="button button-block margin-top-normal more">WIĘCEJ INFORMACJI</a>
             </div>
@@ -73,7 +75,7 @@
             {% endif %}
         </div>
     </div>
-    
+
     {% if upcoming_meetup.sponsors.exists %}
     <div class="row">
         <div class="span10 offset2 margin-top-normal">


### PR DESCRIPTION
- fixing map on home page by using Google Maps JS API like it was before in the meetup detail page
- added include file with maps JS API, so now you can easily add maps with creating map div in the code +:

```
{% block js %}
{% include 'includes/maps_api_script.html' with canvas_id='map-canvas' latitude=latitude longitude=longitude zoom=15 disable_ui=1 %}
{% endblock %}
```

- changing `MIDDLEWARE_CLASSES` in settings to `MIDDLEWARE` (was removed in Django 2.0)