### PR TITLE
use template builtin to preserve sponsor description formatting on display

### DIFF
--- a/meetpy/templates/meetups/sponsor_list.html
+++ b/meetpy/templates/meetups/sponsor_list.html
@@ -11,7 +11,7 @@
                 <div class="row-fluid sponsor-row margin-bottom-small">
                     <div class="span12">
                         <a href="{{ sponsor.website }}" target="_blank" class="no-hover"><img class="img-sponsors" src="{{ sponsor.logo.url }}" alt="{{ sponsor.name }}"></a>
-                        <p>{{ sponsor.description }}</p>
+                        <p>{{ sponsor.description|linebreaksbr }}</p>
                         <p></p>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes https://github.com/meetpy/meetpy/issues/16