### PR TITLE
Slack icon with configurable link to slack on all pages

### DIFF
--- a/meetpy/meetpy/settings/group_constants/constants.py
+++ b/meetpy/meetpy/settings/group_constants/constants.py
@@ -18,6 +18,7 @@ SOCIAL_MEDIA = {
     'facebook': 'https://www.facebook.com/Pykonik-87835845639/',
     'twitter': 'http://twitter.com/pykonik',
     'youtube': 'http://youtube.com/pykonik',
+    'slack': 'https://join-slack.pykonik.org',
 }
 
 FEED_TITLE = 'Pykonik - Kraków Python Users Group'

--- a/meetpy/static/css/style.css
+++ b/meetpy/static/css/style.css
@@ -131,13 +131,38 @@ header{margin:10px 0 30px;}
 #top{margin:20px 0 0 0}
 
 .top-links{float:right}
-.meetup, .facebook, .twitter, .youtube, .rss, .dropdown, .mail{width:30px;height:30px;display:block;float:left}
+.meetup, .facebook, .twitter, .youtube, .rss, .dropdown, .mail, .slack{width:30px;height:30px;display:block;float:left}
 .meetup{background:url("../img/icon-meetup.jpg") 0 0 no-repeat}
 .facebook{background:url("../img/icon-facebook.jpg") 0 0 no-repeat}
 .twitter{background:url("../img/icon-twitter.jpg") 0 0 no-repeat}
 .youtube{background:url("../img/icon-youtube.jpg") 0 0 no-repeat}
 .rss{background:url("../img/icon-rss.jpg") 0 0 no-repeat}
 .mail{background:url("../img/icon-mail.png") 0 0 no-repeat}
+.slack, .slack-footer i{background: #2e2e2e url("../img/icon-slack.svg") 0 0 no-repeat}
+
+.social-media-footer{height: 30px;}
+
+.slack-footer{
+  display: inline-block;
+  margin-top: 10px;
+  height: 31px;
+  text-decoration: none;
+}
+
+.slack-footer span{
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 30px;
+  margin-left: 5px;
+}
+
+.slack-footer i{
+  vertical-align: middle;
+  width: 30px;
+  height: 30px;
+  display: block;
+  float: left;
+}
 
 .pull-right .dropdown-menu{min-width:120px}
 .pull-right .dropdown-menu:after{position:absolute;top:-6px;left:auto;right:8px;display:inline-block;border-right:6px solid transparent;border-bottom:6px solid #ffffff;border-left:6px solid transparent;content:''}

--- a/meetpy/static/img/icon-slack.svg
+++ b/meetpy/static/img/icon-slack.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 270 270"
+   style="enable-background:new 0 0 270 270;"
+   xml:space="preserve"
+   sodipodi:docname="icon-slack.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"><metadata
+     id="metadata35"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs33" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1437"
+     inkscape:window-height="876"
+     id="namedview31"
+     showgrid="false"
+     inkscape:zoom="0.87407407"
+     inkscape:cx="135"
+     inkscape:cy="135"
+     inkscape:window-x="0"
+     inkscape:window-y="1440"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style2">
+	.st0{fill:#E01E5A;}
+	.st1{fill:#36C5F0;}
+	.st2{fill:#2EB67D;}
+	.st3{fill:#ECB22E;}
+</style><g
+     id="g28"
+     transform="matrix(1.6148899,0,0,1.6148899,-83.010129,-83.010129)"><g
+       id="g8"><path
+         class="st0"
+         d="m 99.4,151.2 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 h 12.9 z"
+         id="path4"
+         inkscape:connector-curvature="0"
+         style="fill:#e01e5a" /><path
+         class="st0"
+         d="m 105.9,151.2 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 v 32.3 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 z"
+         id="path6"
+         inkscape:connector-curvature="0"
+         style="fill:#e01e5a" /></g><g
+       id="g14"><path
+         class="st1"
+         d="m 118.8,99.4 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 v 12.9 z"
+         id="path10"
+         inkscape:connector-curvature="0"
+         style="fill:#36c5f0" /><path
+         class="st1"
+         d="m 118.8,105.9 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 H 86.5 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 z"
+         id="path12"
+         inkscape:connector-curvature="0"
+         style="fill:#36c5f0" /></g><g
+       id="g20"><path
+         class="st2"
+         d="m 170.6,118.8 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 h -12.9 z"
+         id="path16"
+         inkscape:connector-curvature="0"
+         style="fill:#2eb67d" /><path
+         class="st2"
+         d="m 164.1,118.8 c 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 V 86.5 c 0,-7.1 5.8,-12.9 12.9,-12.9 7.1,0 12.9,5.8 12.9,12.9 z"
+         id="path18"
+         inkscape:connector-curvature="0"
+         style="fill:#2eb67d" /></g><g
+       id="g26"><path
+         class="st3"
+         d="m 151.2,170.6 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 -7.1,0 -12.9,-5.8 -12.9,-12.9 v -12.9 z"
+         id="path22"
+         inkscape:connector-curvature="0"
+         style="fill:#ecb22e" /><path
+         class="st3"
+         d="m 151.2,164.1 c -7.1,0 -12.9,-5.8 -12.9,-12.9 0,-7.1 5.8,-12.9 12.9,-12.9 h 32.3 c 7.1,0 12.9,5.8 12.9,12.9 0,7.1 -5.8,12.9 -12.9,12.9 z"
+         id="path24"
+         inkscape:connector-curvature="0"
+         style="fill:#ecb22e" /></g></g></svg>

--- a/meetpy/templates/base.html
+++ b/meetpy/templates/base.html
@@ -66,6 +66,9 @@
 						</div>
 						<div class="span3">
 							<div class="top-links">
+                {% if group.social.slack %}
+                                <a href="{{ group.social.slack }}" class="slack" target="_blank" title="Slack"></a>
+                {% endif %}
                 {% if group.social.meetup %}
   								<a href="{{ group.social.meetup }}" class="meetup" target="_blank"></a>
                 {% endif %}
@@ -113,7 +116,7 @@
                         </div>
                         <div class="span2">
                             <h5>Jesteśmy na</h5>
-                            <ul>
+                            <ul class="social-media-footer">
                                 {% if group.social.meetup %}
                                     <li><a href="{{ group.social.meetup }}" class="meetup" target="_blank"></a></li>
                                 {% endif %}
@@ -127,6 +130,12 @@
                                     <li><a href="{{ group.social.youtube }}" class="youtube" target="_blank"></a></li>
                                 {% endif %}
                             </ul>
+                        {% if group.social.slack %}
+                            <a href="{{ group.social.slack }}" class="slack-footer">
+                                <i class="slack-icon"></i>
+                                <span>Join Slack</span>
+                            </a>
+                        {% endif %}
                         </div>
                         <div class="span2">
                             <h5>Python w Polsce</h5>


### PR DESCRIPTION
This PR adds new sgv icon among the social links for Slack of the group. Icon is also added to the footer with extra "Join Slack" text, so now viewers will be able to find the Slack server.

Adding icon into the footer required adding new styles. 

Closes #23 