### PR TITLE
Bump pillow to a version for which windows wheels do exist

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ gunicorn==19.7.1
 idna==2.5
 packaging==16.8
 paramiko==2.1.2
-Pillow==2.9.0
+Pillow==6.2.0
 pyasn1==0.2.3
 pycparser==2.17
 pyparsing==2.2.0


### PR DESCRIPTION
See https://pillow.readthedocs.io/en/stable/installation.html#notes for compatibility matrix