### PR TITLE
#64 bump requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django~=3.2.15
+Django~=3.2.22
 Pillow
 discord-webhook~=1.3.0
 django-embed-video

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ atomicwrites==1.3.0
     # via pytest
 attrs==19.3.0
     # via pytest
-certifi==2019.9.11
+certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.0
     # via requests
@@ -18,7 +18,7 @@ coverage==4.5.4
     # via pytest-cov
 discord-webhook==1.3.0
     # via -r requirements.in
-django==3.2.15
+django==3.2.22
     # via
     #   -r requirements.in
     #   django-embed-video
@@ -45,7 +45,7 @@ more-itertools==7.2.0
     # via pytest
 packaging==19.2
     # via pytest
-pillow==6.2.1
+pillow==8.4.0
     # via -r requirements.in
 pluggy==0.13.0
     # via pytest
@@ -66,7 +66,7 @@ python-dateutil==2.8.1
     # via faker
 pytz==2019.3
     # via django
-pyyaml==5.1.2
+pyyaml==6.0.1
     # via -r requirements.in
 requests==2.31.0
     # via


### PR DESCRIPTION
- Bump pillow to the latest version.
- Bump Django to the latest 3.2 release.
- Bump certifi to the latest version.
- Bump pyyaml to the latest version.

Fixes #64.